### PR TITLE
Fix __init__.py file opening at setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import ast
 
 # Dynamically calculate the version
 version = None
-with file(os.path.join('zignal', '__init__.py')) as fp:
+with open(os.path.join('zignal', '__init__.py'), 'r') as fp:
     for line in fp:
         if line.startswith('__version__'):
             version = ast.parse(line).body[0].value.s


### PR DESCRIPTION
The line "with file(os.path.join(..." was not working because "file" was not recognized. Changing to "open" solved the problem while installing zignal at Python 3.