### PR TITLE
Fix _fade() raising TypeError

### DIFF
--- a/zignal/audio.py
+++ b/zignal/audio.py
@@ -229,7 +229,7 @@ class Audio(object):
         fade_seconds = millisec/1000
         assert self.duration > fade_seconds, "fade cannot be longer than the length of the audio"
 
-        sample_count = np.ceil(fade_seconds*self.fs)
+        sample_count = int(np.ceil(fade_seconds*self.fs))
         self._logger.debug("fade %s sample count: %i" %(direction, sample_count))
 
         # generate the ramp


### PR DESCRIPTION
This PR fixes the `_fade()` method raising TypeError: 'numpy.float64' object cannot be interpreted as an integer. It was fixed by converting `sample_count` into an integer before calling `np.linspace()`.