### PR TITLE
Silence multiple SyntaxWarning when compiling to pycache

### DIFF
--- a/zignal/audio.py
+++ b/zignal/audio.py
@@ -233,7 +233,7 @@ class Audio(object):
         self._logger.debug("fade %s sample count: %i" %(direction, sample_count))
 
         # generate the ramp
-        if direction is "out":
+        if direction == "out":
             # ramp down
             ramp = np.linspace(1, 0, num=sample_count, endpoint=True)
         else:
@@ -243,7 +243,7 @@ class Audio(object):
         ones = np.ones(len(self)-len(ramp))
 
         # glue the ones and the ramp together
-        if direction is "out":
+        if direction == "out":
             gains = np.append(ones, ramp, axis=0)
         else:
             gains = np.append(ramp, ones, axis=0)

--- a/zignal/measure/mls.py
+++ b/zignal/measure/mls.py
@@ -63,7 +63,7 @@ class _MLS_base(object):
         assert N    is not None, "Please specify MLS order"
         assert taps is not None, "Please specify feedback taps"
         assert isinstance(taps, (tuple, list))
-        assert len(taps) is not 0, "taps are empty!"
+        assert len(taps) != 0, "taps are empty!"
 
         self._logger    = logging.getLogger(__name__)
         self.N          = N


### PR DESCRIPTION
The warning 'SyntaxWarning: "is" with a literal. Did you mean "=="?' is emitted when the audio.py is compiled into a .pyc file. There is also a similar warning made by measure/mls.py: 'SyntaxWarning: "is not" with a literal. Did you mean "!="?'

This doesn't otherwise affect correct behavior of the library but I just silenced these warnings.