### PR TITLE
Remove nose as unit test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ flake8:
 
 .PHONY: test
 test:
-	nosetests
+	python -m unittest -v zignal/tests/test_*.py
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See the examples folder for more examples.
 
 ## Requirements
 
-This library relies on numpy, scipy, matplotlib and optionally pyaudio (and nose for unit testing). It is recommended to create a virtual environment and let pip install the dependencies automatically.
+This library relies on numpy, scipy, matplotlib and optionally pyaudio. It is recommended to create a virtual environment and let pip install the dependencies automatically.
 
     python3 -m venv <name-of-virtualenv>
     . <name-of-virtualenv>/bin/activate

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
                            ],
     extras_require      = {
                            'sndcard': ['pyaudio'],
-                           'testing': ['nose'],
                           },
     url                 = 'https://github.com/ronnyandersson/zignal',
     download_url        = 'https://pypi.python.org/pypi/zignal',

--- a/zignal/tests/test_audio_constructor.py
+++ b/zignal/tests/test_audio_constructor.py
@@ -7,10 +7,10 @@ Created on 28 Feb 2014
 '''
 
 # Standard library
+import logging
 import unittest
 
 # Third party
-import nose
 import numpy as np
 
 # Internal
@@ -20,7 +20,6 @@ from zignal import Audio
 class Test_EmptyConstructor(unittest.TestCase):
     def setUp(self):
         self.x = Audio()
-        print(self.x)
 
     def test_default_constructor(self):
         self.assertAlmostEqual(self.x.fs, 96000, places=7)
@@ -40,15 +39,12 @@ class Test_EmptyConstructor(unittest.TestCase):
 
         s = 'This is a comment\nwith a line break'
         self.x.comment(comment=s)
-        print(self.x)
-
-        self.assertSequenceEqual(self.x.comment(), s)
+        self.assertSequenceEqual(self.x.comment(), s, msg="\n"+str(self.x))
 
 
 class Test_ConstructorChannels(unittest.TestCase):
     def setUp(self):
         self.x = Audio(channels=4)
-        print(self.x)
 
     def test_str_method(self):
         self.assertIsInstance(self.x.__str__(), str)
@@ -58,47 +54,43 @@ class Test_ConstructorChannels(unittest.TestCase):
         self.assertEqual(len(self.x), 0)
 
     def test_RMS_is_nan(self):
-        print(self.x.rms())
-        self.assertTrue(np.isnan(self.x.rms()).all())
+        self.assertTrue(np.isnan(self.x.rms()).all(), msg=self.x.rms())
 
     def test_peak_is_nan(self):
         peak, idx = self.x.peak()
-        print(peak)
-        print(idx)
-        self.assertTrue(np.isnan(peak).all())
-        self.assertTrue((idx == 0).all())
+        self.assertTrue(np.isnan(peak).all(), msg=str(peak))
+        self.assertTrue((idx == 0).all(), msg=str(idx))
 
     def test_crestfactor_is_nan(self):
-        print(self.x.crest_factor())
-        self.assertTrue(np.isnan(self.x.crest_factor()).all())
+        self.assertTrue(np.isnan(self.x.crest_factor()).all(), msg=self.x.crest_factor())
 
 
 class Test_ConstructorDuration(unittest.TestCase):
     def test_set_samples(self):
         x = Audio(nofsamples=300, fs=600)
-        print(x)
-        self.assertAlmostEqual(x.duration, 0.5, places=7)
+        self.assertAlmostEqual(x.duration, 0.5, places=7, msg="\n"+str(x))
 
     def test_set_duration(self):
         x = Audio(duration=1.5, fs=600)
-        print(x)
-        self.assertEqual(len(x), 900)
+        self.assertEqual(len(x), 900, msg="\n"+str(x))
 
     def test_set_duration_and_channels(self):
         x = Audio(duration=1.5, fs=600, channels=5)
-        print(x)
-        self.assertEqual(len(x), 900)
+        self.assertEqual(len(x), 900, msg="\n"+str(x))
 
     def test_set_duration_and_samples(self):
-        self.assertRaises(AssertionError, callableObj=Audio, nofsamples=10, duration=1.1)
+        self.assertRaises(AssertionError, Audio, nofsamples=10, duration=1.1)
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)

--- a/zignal/tests/test_audio_datatype_conversion.py
+++ b/zignal/tests/test_audio_datatype_conversion.py
@@ -7,10 +7,10 @@ Created on 28 Feb 2014
 '''
 
 # Standard library
+import logging
 import unittest
 
 # Third party
-import nose
 import numpy as np
 
 # Internal
@@ -22,9 +22,9 @@ class Test_ConvertBackToBack(unittest.TestCase):
         self.x = Audio(fs=10, initialdata=np.zeros((10, 1)))
         self.x.samples[0] = -1.0
         self.x.samples[1] =  1.0                                            # noqa: E222
-        print(self.x)
-        print(self.x.samples)
-        print()
+        #print(self.x)
+        #print(self.x.samples)
+        #print()
 
     def quantization_step_size(self, bits):
         return 2**-(bits-1)
@@ -32,8 +32,8 @@ class Test_ConvertBackToBack(unittest.TestCase):
     def test_float_to_int8_to_float64(self):
         self.x.convert_to_integer(targetbits=8)
         self.x.convert_to_float(targetbits=64)
-        print(self.x)
-        print(self.x.samples)
+        #print(self.x)
+        #print(self.x.samples)
 
         q = self.quantization_step_size(8)
         self.assertAlmostEqual(self.x.samples[0], -1.0 + q, places=20)
@@ -42,8 +42,8 @@ class Test_ConvertBackToBack(unittest.TestCase):
     def test_float_to_int16_to_float64(self):
         self.x.convert_to_integer(targetbits=16)
         self.x.convert_to_float(targetbits=64)
-        print(self.x)
-        print(self.x.samples)
+        #print(self.x)
+        #print(self.x.samples)
 
         q = self.quantization_step_size(16)
         self.assertAlmostEqual(self.x.samples[0], -1.0 + q, places=20)
@@ -52,8 +52,8 @@ class Test_ConvertBackToBack(unittest.TestCase):
     def test_float_to_int32_to_float64(self):
         self.x.convert_to_integer(targetbits=32)
         self.x.convert_to_float(targetbits=64)
-        print(self.x)
-        print(self.x.samples)
+        #print(self.x)
+        #print(self.x.samples)
 
         q = self.quantization_step_size(32)
         self.assertAlmostEqual(self.x.samples[0], -1.0 + q, places=20)
@@ -65,14 +65,14 @@ class Test_ConvertFloatToInt(unittest.TestCase):
         self.x = Audio(fs=10, initialdata=np.zeros((10, 1)))
         self.x.samples[0] = -1.0
         self.x.samples[1] =  1.0                                            # noqa: E222
-        print(self.x)
-        print(self.x.samples)
-        print()
+        #print(self.x)
+        #print(self.x.samples)
+        #print()
 
     def convert(self, targetbits=None):
         self.x.convert_to_integer(targetbits=targetbits)
-        print(self.x)
-        print(self.x.samples)
+        #print(self.x)
+        #print(self.x.samples)
 
         self.assertIsInstance(self.x.samples, np.ndarray)
 
@@ -109,14 +109,14 @@ class Test_ConvertFloatToInt(unittest.TestCase):
 
 class Test_ConvertIntToFloat32(unittest.TestCase):
     def convert(self, y, targetbits=None):
-        print(y)
-        print(y.pretty_string_samples())
-        print()
+        #print(y)
+        #print(y.pretty_string_samples())
+        #print()
 
         y.convert_to_float(targetbits=targetbits)
-        print(y)
-        print(y.pretty_string_samples())
-        print()
+        #print(y)
+        #print(y.pretty_string_samples())
+        #print()
 
     def test_int8(self):
         x = Audio(fs=10, initialdata=np.zeros((10, 1), dtype=np.int8))
@@ -151,11 +151,14 @@ class Test_ConvertIntToFloat32(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)

--- a/zignal/tests/test_audio_peak.py
+++ b/zignal/tests/test_audio_peak.py
@@ -7,10 +7,10 @@ Created on 31 Oct 2014
 '''
 
 # Standard library
+import logging
 import unittest
 
 # Third party
-import nose
 import numpy as np
 
 # Internal
@@ -28,8 +28,8 @@ class Test_single_channel(unittest.TestCase):
         self.assertTrue(len(peak) == 1)
         self.assertTrue(len(idx) == 1)
 
-        print("index: %3i  peak: %f" % (idx, peak))
-        print(x)
+        #print("index: %3i  peak: %f" % (idx, peak))
+        #print(x)
 
         self.assertAlmostEqual(peak, expected, places=3)
         self.assertEqual(idx, position)
@@ -38,14 +38,14 @@ class Test_single_channel(unittest.TestCase):
         self.y[1] =  2.0                            # noqa: E222
         self.y[2] =  2.2    # <-- peak              # noqa: E222
         self.y[3] = -1.2
-        print("init data: %s" % self.y)
+        #print("init data: %s" % self.y)
         self.check_values(self.y, 2.2, 2)
 
     def test_negative(self):
         self.y[1] =  2.0                            # noqa: E222
         self.y[2] =  3.19                           # noqa: E222
         self.y[3] = -3.2    # <-- peak
-        print("init data: %s" % self.y)
+        #print("init data: %s" % self.y)
         self.check_values(self.y, -3.2, 3)
 
 
@@ -60,8 +60,8 @@ class Test_multi_channel(unittest.TestCase):
         self.assertTrue(len(peak) == 2)
         self.assertTrue(len(idx) == 2)
 
-        print("index: %s  peak: %s" % (idx, peak))
-        print(x)
+        #print("index: %s  peak: %s" % (idx, peak))
+        #print(x)
 
         self.assertAlmostEqual(peak[0], expected[0], places=3)
         self.assertAlmostEqual(peak[1], expected[1], places=3)
@@ -75,7 +75,7 @@ class Test_multi_channel(unittest.TestCase):
 
         self.y[1][1] = -4.1     # <-- peak
         self.y[2][1] =  3.0                         # noqa: E222
-        print(self.y)
+        #print(self.y)
         self.check_values(self.y, [2.3, -4.1], [2, 1])
 
     def test_negative(self):
@@ -84,16 +84,19 @@ class Test_multi_channel(unittest.TestCase):
 
         self.y[0][1] = -4.0     # <-- peak
         self.y[1][1] =  3.0                         # noqa: E222
-        print(self.y)
+        #print(self.y)
         self.check_values(self.y, [2, -4], [2, 0])
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)

--- a/zignal/tests/test_db_conversions.py
+++ b/zignal/tests/test_db_conversions.py
@@ -7,10 +7,10 @@ Created on 23 Oct 2014
 '''
 
 # Standard library
+import logging
 import unittest
 
 # Third party
-import nose
 import numpy as np
 
 # Internal
@@ -208,11 +208,14 @@ class Test_db_to_lin_input_datatypes(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)

--- a/zignal/tests/test_linearfilter.py
+++ b/zignal/tests/test_linearfilter.py
@@ -7,10 +7,8 @@ Created on 21 Jun 2015
 '''
 
 # Standard library
+import logging
 import unittest
-
-# Third party
-import nose
 
 # Internal
 from zignal.filters import linearfilter
@@ -28,7 +26,7 @@ class Test_Filter(unittest.TestCase):
         B = (0.1, 0.2, 0.3)
         A = (0.4, 0.5, 0.6)
         f = linearfilter.Filter(B, A, fs=48000)
-        print(f)
+        #print(f)
 
         self.verify_coefficients(f, B, A)
 
@@ -36,7 +34,7 @@ class Test_Filter(unittest.TestCase):
         B = (0.1, 0.2, 0.3)
         A = (0.4, 0.5, 0.6)
         f = linearfilter.Filter(B, A, fs=48000)
-        print(f)
+        #print(f)
 
         BB = f.get_feed_forward()
 
@@ -46,7 +44,7 @@ class Test_Filter(unittest.TestCase):
         B = (0.1, 0.2, 0.3)
         A = (0.4, 0.5, 0.6)
         f = linearfilter.Filter(B, A, fs=48000)
-        print(f)
+        #print(f)
 
         AA = f.get_feed_back()
 
@@ -56,7 +54,7 @@ class Test_Filter(unittest.TestCase):
         B = (0.1, 0.2, 0.3)
         A = (0.4, 0.5, 0.6)
         f = linearfilter.Filter(B, A, fs=48000)
-        print(f)
+        #print(f)
 
         f.normalise()
         unused_BB, AA = f.get_coefficients()
@@ -67,7 +65,7 @@ class Test_Filter(unittest.TestCase):
         A = (1.1, 1.2, 1.3)
         f = linearfilter.Filter(fs=48000)
         f.set_coefficients(B, A)
-        print(f)
+        #print(f)
 
         self.verify_coefficients(f, B, A)
 
@@ -88,11 +86,14 @@ class Test_normalised_frequency(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)

--- a/zignal/tests/test_music_scales.py
+++ b/zignal/tests/test_music_scales.py
@@ -7,10 +7,8 @@ Created on 24 Feb 2015
 '''
 
 # Standard library
+import logging
 import unittest
-
-# Third party
-import nose
 
 # Internal
 from zignal.music import scales
@@ -120,11 +118,14 @@ class Test_piano(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)

--- a/zignal/tests/test_music_spn.py
+++ b/zignal/tests/test_music_spn.py
@@ -7,10 +7,8 @@ Created on 21 Feb 2015
 '''
 
 # Standard library
+import logging
 import unittest
-
-# Third party
-import nose
 
 # Internal
 from zignal.music import spn
@@ -126,11 +124,14 @@ class Test_index2key(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)

--- a/zignal/tests/test_sine.py
+++ b/zignal/tests/test_sine.py
@@ -7,10 +7,8 @@ Created on 26 Oct 2014
 '''
 
 # Standard library
+import logging
 import unittest
-
-# Third party
-import nose
 
 # Internal
 from zignal import Sinetone, SquareWave
@@ -21,19 +19,19 @@ class Test_Sinetone(unittest.TestCase):
         fs = 100
         f0 = 1
         x = Sinetone(f0=f0, fs=fs, duration=1, gaindb=20)
-        print(x)
-        print(x.samples[-5:, :])
+        #print(x)
+        #print(x.samples[-5:, :])
         # We've created a one period sine. The last sample should not be
         # very close to zero. If it were, then a concatenation of two
         # sines would mean that we have one zero value too many at the
         # concatenation point --> discontinuity
-        self.assertNotAlmostEqual(float(x.samples[-1]), 0, places=5)
+        self.assertNotAlmostEqual(float(x.samples[-1, 0]), 0.0, places=5)
 
     def test_center_frequency(self):
         fs = 48000
         f0 = 997
         x = Sinetone(f0=f0, fs=fs, duration=2, gaindb=20)
-        print(x)
+        #print(x)
         freq, mag = x.fft(window="rectangular")
 
         self.assertAlmostEqual(freq[mag.argmax()], f0, places=7)
@@ -46,14 +44,14 @@ class Test_SetSampleRate(unittest.TestCase):
         self.f0     = 100
         self.x      = Sinetone(f0=self.f0, fs=self.fs, duration=self.dur, gaindb=-10)
 
-        print(self.id())
-        print('Before:\n%s' % self.x)
+        #print(self.id())
+        #print('Before:\n%s' % self.x)
 
     def test_duration_fs_up_2_5(self):
         self.assertAlmostEqual(self.x.duration, self.dur, places=5)
 
         self.x.set_sample_rate(self.fs*2.5)
-        print('After:\n%s' % self.x)
+        #print('After:\n%s' % self.x)
 
         self.assertAlmostEqual(self.x.duration, self.dur/2.5, places=5)
 
@@ -61,7 +59,7 @@ class Test_SetSampleRate(unittest.TestCase):
         self.assertAlmostEqual(self.x.duration, self.dur, places=5)
 
         self.x.set_sample_rate(self.fs/2.5)
-        print('After:\n%s' % self.x)
+        #print('After:\n%s' % self.x)
 
         self.assertAlmostEqual(self.x.duration, self.dur*2.5, places=5)
 
@@ -69,7 +67,7 @@ class Test_SetSampleRate(unittest.TestCase):
         self.assertAlmostEqual(self.x.f0, self.f0, places=5)
 
         self.x.set_sample_rate(self.fs/3)
-        print('After:\n%s' % self.x)
+        #print('After:\n%s' % self.x)
 
         self.assertAlmostEqual(self.x.f0, self.f0/3, places=5)
 
@@ -77,7 +75,7 @@ class Test_SetSampleRate(unittest.TestCase):
         self.assertAlmostEqual(self.x.f0, self.f0, places=5)
 
         self.x.set_sample_rate(self.fs*3)
-        print('After:\n%s' % self.x)
+        #print('After:\n%s' % self.x)
 
         self.assertAlmostEqual(self.x.f0, self.f0*3, places=5)
 
@@ -91,11 +89,14 @@ class Test_SetSampleRate_Square(Test_SetSampleRate):
 
 
 if __name__ == "__main__":
-    noseargs = [__name__,
-                "--verbosity=2",
-                "--logging-format=%(asctime)s %(levelname)-8s: %(name)-15s " +
-                "%(module)-15s %(funcName)-20s %(message)s",
-                "--logging-level=DEBUG",
-                __file__,
-                ]
-    nose.run(argv=noseargs)
+    logging.basicConfig(
+        format="%(levelname)-8s: %(module)s.%(funcName)-15s %(message)s",
+        level="DEBUG",
+        )
+    # some libraries are noisy in DEBUG
+    logging.getLogger("matplotlib").setLevel(logging.INFO)
+    logging.getLogger("PIL").setLevel(logging.WARNING)
+
+    # from command line:
+    # $ python -m unittest -v zignal/tests/<filename>.py
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Minor bugfixes to the tests to make them run again.

Comment out direct prints in the unit tests. Nosetest used to hide prints to stdout but pythons builtin unittest framework does not. So a quick fix for now is to just comment out the printouts. Might update later to use the logging feature better, if needed.

Fixes #8
Closes #9